### PR TITLE
modified require path

### DIFF
--- a/lib/chef/knife/twitter_post.rb
+++ b/lib/chef/knife/twitter_post.rb
@@ -1,4 +1,5 @@
-require "knife-twitter"
+#require "knife-twitter"
+require 'chef/knife/twitter'
 require 'chef/knife'
 
 class Chef

--- a/lib/chef/knife/twitter_timeline.rb
+++ b/lib/chef/knife/twitter_timeline.rb
@@ -1,4 +1,5 @@
-require "knife-twitter"
+#require "knife-twitter"
+require 'chef/knife/twitter'
 require 'chef/knife'
 
 class Chef


### PR DESCRIPTION
In my environment(ruby 1.9.3p194/gem 1.8.23/Chef: 11.4.4) catch following error.

```
/var/lib/gems/1.9.1/gems/knife-twitter-0.1.0/lib/chef/knife/twitter_timeline.rb:7:in `<class:TwitterTl>': uninitialized constant Chef::Knife::TwitterTl::TwitterBase (NameError)
```

I added comment-out "require 'knife-twitter'" and added "require 'chef/knife/twitter'" in twitter_timeline.rb and twitter_post.rb

Please confirm.

Thank you.
